### PR TITLE
Avoid mongoose unstable versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "express": "^4.9.7",
     "express-session": "^1.8.2",
     "lodash": "^3.5.0",
-    "mongoose": "^3.8.18",
+    "mongoose": "3.8",
     "passport": "~0.2.1",
     "passport-local": "~1.0.0"
   },


### PR DESCRIPTION
mongoose doesn't follow the semver convention.
We must stuck to the `3.8` branch or bump to `4.0`.
